### PR TITLE
fix getReceiveApplicationContext

### DIFF
--- a/Libraries/RNWatch/WatchBridge.m
+++ b/Libraries/RNWatch/WatchBridge.m
@@ -308,6 +308,7 @@ RCT_EXPORT_METHOD(getApplicationContext:(RCTResponseSenderBlock)callback) {
 - (void)session:(WCSession *)session
 didReceiveApplicationContext:(NSDictionary<NSString *,id> *)applicationContext {
   NSLog(@"sessionDidReceiveApplicationContext %@", applicationContext);
+  [self.session updateApplicationContext:applicationContext error:nil];
   [self dispatchEventWithName:EVENT_APPLICATION_CONTEXT_RECEIVED body:self.session.applicationContext];
 }
 


### PR DESCRIPTION
applicationContext was not updated if the app was not running, so getApplicationContext doesn't work to get data from the watch on iOS app launching.